### PR TITLE
configure bad request response before creating it

### DIFF
--- a/Amazon.ApplicationLoadBalancer.Identity.AspNetCore/ALBIdentityMiddleware.cs
+++ b/Amazon.ApplicationLoadBalancer.Identity.AspNetCore/ALBIdentityMiddleware.cs
@@ -225,9 +225,9 @@
 
         private static async Task BadRequest(HttpContext httpContext, string message)
         {
-            await httpContext.Response.WriteAsync(message);
             httpContext.Response.StatusCode = 400;
             httpContext.Response.Headers.Add(ContentTypeHeader, ContentTypeValue);
+            await httpContext.Response.WriteAsync(message);
         }
 
         private static ECDsaSecurityKey ConvertPemToSecurityKey(string pem)


### PR DESCRIPTION
`await httpContext.Response.WriteAsync(message)` sets the `Response.HasStarted` flag to `true`, preventing the proceeding two lines from modifying the response and causing an exception. Now a bad request response is returned as expected.